### PR TITLE
[BUGFIX] Checks for null before comparing.

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -143,7 +143,7 @@ find_finfo(char *abspath, char *hash)
     while (i >= 0) {
 	if (!strcmp(abspath, finfo[i].abspath)
 	    && ((hash == NULL && finfo[i].hash == NULL)
-		|| !strcmp(hash, finfo[i].hash))) {
+		|| (hash != NULL && finfo[i].hash != NULL && !strcmp(hash, finfo[i].hash)))) {
 	    break;
 	}
 


### PR DESCRIPTION
There was a bug there that was just too rare to occur. If for any reason two files shared a name, but the first one was a regular file and the second was a folder a segfault would pop up since we would `strcmp(NULL, NOT_NULL)` or vice-versa.