### PR TITLE
[IMPROVEMENT] Be consistent when reporting errors

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -91,7 +91,9 @@ hash_file_contents(char *name, size_t sz)
     SHA1_Update(&ctx, buf, sz);
     SHA1_Final(hash, &ctx);
 
-    close(fd);
+    if (close(fd) < 0) {
+	error(EXIT_FAILURE, errno, "on hash close(2)");
+    }
 
     if (munmap(buf, sz) < 0) {
 	error(EXIT_FAILURE, errno, "unmapping `%s'", name);

--- a/src/record.c
+++ b/src/record.c
@@ -26,6 +26,9 @@ void
 record_start(char *fname)
 {
     fout = fopen(fname, "w");
+    if (fout == NULL) {
+	error(EXIT_FAILURE, errno, "on record_start fopen");
+    }
 
     fprintf(fout,
 	    "@prefix b:  <http://example.org/build-recorder#> .\n"
@@ -68,7 +71,9 @@ get_cmdline(pid_t pid)
     char data[CMD_LINE_SIZE + 1];
     ssize_t n = read(fd, data, CMD_LINE_SIZE);
 
-    close(fd);
+    if (close(fd)) {
+	error(EXIT_FAILURE, errno, "on get_cmdline close");
+    }
 
     if (n < 0) {
 	error(EXIT_FAILURE, errno, "on get_cmdline read");

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -143,7 +143,7 @@ find_finfo(char *abspath, char *hash)
     while (i >= 0) {
 	if (!strcmp(abspath, finfo[i].abspath)
 	    && ((hash == NULL && finfo[i].hash == NULL)
-		|| !strcmp(hash, finfo[i].hash))) {
+		|| (hash != NULL && finfo[i].hash != NULL && !strcmp(hash, finfo[i].hash)))) {
 	    break;
 	}
 


### PR DESCRIPTION
Some system and library calls weren't ever checked for errors, we lacked consistency.

So I added the checks to all of them except the string manipulating functions,