### PR TITLE
Update hashing code

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -82,7 +82,8 @@
 -Tva_list
 
 /* OpenSSL types */
--TSHA_CTX
+-TEVP_MD
+-TEVP_MD_CTX
 
 /* project-specific types */
 -TFILE_INFO

--- a/configure.ac
+++ b/configure.ac
@@ -27,11 +27,11 @@ AC_CONFIG_SRCDIR([src/main.c])
 
 dnl Checks for programs
 dnl Checks for libraries
-AC_CHECK_LIB(crypto, SHA1_Init,, AC_MSG_ERROR([cannot find libcrypto]))
+AC_CHECK_LIB(crypto, EVP_sha1,, AC_MSG_ERROR([cannot find libcrypto]))
 
 dnl Checks for headers
 AC_CHECK_HEADER([linux/ptrace.h],, AC_MSG_ERROR([cannot find linux/ptrace.h]))
-AC_CHECK_HEADER([openssl/sha.h],, AC_MSG_ERROR([cannot find openssl/sha.h]))
+AC_CHECK_HEADER([openssl/evp.h],, AC_MSG_ERROR([cannot find openssl/evp.h]))
 AC_CHECK_HEADER([sys/mman.h],, AC_MSG_ERROR([cannot find sys/mman.h]))
 AC_CHECK_HEADER([sys/ptrace.h],, AC_MSG_ERROR([cannot find sys/ptrace.h]))
 AC_CHECK_HEADER([sys/signal.h],, AC_MSG_ERROR([cannot find sys/signal.h]))
@@ -46,8 +46,6 @@ dnl Checks for typedefs and structures
 AC_CHECK_TYPE([struct ptrace_syscall_info],, AC_MSG_ERROR([cannot find struct ptrace_syscall_info]), [#include <linux/ptrace.h>])
 
 AC_CHECK_TYPE([pid_t],, AC_MSG_ERROR([cannot find pid_t]), [#include <sys/types.h>])
-
-AC_CHECK_TYPE([SHA_CTX],, AC_MSG_ERROR([cannot find SHA_CTX]), [#include <openssl/sha.h>])
 
 AC_CHECK_DECL([PATH_MAX],, AC_MSG_ERROR([cannot find PATH_MAX]), [#include <linux/limits.h>])
 AC_CHECK_DECL([ARG_MAX],, AC_MSG_ERROR([cannot find ARG_MAX]), [#include <linux/limits.h>])
@@ -76,16 +74,16 @@ AC_CHECK_DECL([SYS_close],, AC_MSG_ERROR([cannot find SYS_close]), [#include <sy
 AC_CHECK_DECL([MADV_SEQUENTIAL],, AC_MSG_ERROR([cannot find MADV_SEQUENTIAL]), [#include <sys/mman.h>])
 
 dnl Checks for functions
-AC_CHECK_FUNC([SHA1_Init],, AC_MSG_ERROR([cannot find SHA1_Init(3)]))
-AC_CHECK_FUNC([SHA1_Update],, AC_MSG_ERROR([cannot find SHA1_Update(3)]))
-AC_CHECK_FUNC([SHA1_Final],, AC_MSG_ERROR([cannot find SHA1_Final(3)]))
-
 AC_CHECK_FUNC([fork],, AC_MSG_ERROR([cannot find fork(2)]))
 AC_CHECK_FUNC([ptrace],, AC_MSG_ERROR([cannot find ptrace(2)]))
 AC_CHECK_FUNC([waitpid],, AC_MSG_ERROR([cannot find waitpid(2)]))
 
 AC_CHECK_FUNC([mmap],, AC_MSG_ERROR([cannot find mmap(2)]))
 AC_CHECK_FUNC([madvise],, AC_MSG_ERROR([cannot find madvise(2)]))
+
+AC_CHECK_FUNC([EVP_DigestInit_ex],, AC_MSG_ERROR([cannot find EVP_DigestInit_ex(3)]))
+AC_CHECK_FUNC([EVP_DigestUpdate],, AC_MSG_ERROR([cannot find EVP_DigestUpdate(3)]))
+AC_CHECK_FUNC([EVP_DigestFinal_ex],, AC_MSG_ERROR([cannot find EVP_DigestFinal_ex(3)]))
 
 dnl We need a C compiler
 AC_PROG_CC

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -143,7 +143,8 @@ find_finfo(char *abspath, char *hash)
     while (i >= 0) {
 	if (!strcmp(abspath, finfo[i].abspath)
 	    && ((hash == NULL && finfo[i].hash == NULL)
-		|| !strcmp(hash, finfo[i].hash))) {
+		|| (hash != NULL && finfo[i].hash != NULL
+		    && !strcmp(hash, finfo[i].hash)))) {
 	    break;
 	}
 


### PR DESCRIPTION
- openat(2) now handled properly
- autoconf now links with libcrypto
- requested changes
- indent
- added autoconf checks
- headers now in a single lexicographical ordered list
- removed open_files, now each file with a file descriptor "fd" is placed at finfo[fd] array index
- indent
- fixed bug where ARM autoconf wouldn't accept multiline checks without m4_normalize
- Add first pass of description of output format
- Fix missing include for uint8_t type
- Add another missing header (for ptrace_syscall_info)
- Add prototypes of recording functions
- we shouldn't rely on include order, that's a recipe for disaster
- Instead of having 3 parameters, take a convenient FILE_INFO structure. More readable, better performance(we don't need to copy)
- now includes sys/types.h instead of types.h
- shouldn't use FILE_INFO, it's a separate module
- creat is now handled properly
- no longer throws an error if more than 1024 files are open concurrently
- Uses newer OpenSSL hash functions
- Closes #32
- No hash string for unmappable files
- Fixes #167
