### PR TITLE
Not making examples and benchmark by default

### DIFF
--- a/benchmark/Makefile.am
+++ b/benchmark/Makefile.am
@@ -18,7 +18,9 @@ $(error Did not find "time" in the PATH.)
 endif
 
 
-all: $(BENCHOUT)
+all:
+
+benchmark: $(BENCHOUT)
 
 $(LOCAL_FILE):
 	$(DOWNLOAD) $(DL_URL)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -11,7 +11,9 @@ EXAMPLES = \
 	compile_two_files \
 	$(EMPTY)
 
-all: $(EXAMPLES)
+all:
+
+examples: $(EXAMPLES)
 
 compile_single_file: f1.c
 	$(EXE) -o $@.out $(CC) -c $^


### PR DESCRIPTION
Makes examples and benchmark non-default rules.

Since these directories are now included in the recursive top-level make, they should not be performed on the target `all`.

Fixes #194
