### PR TITLE
fix autoconf

### DIFF
--- a/benchmark/Makefile.am
+++ b/benchmark/Makefile.am
@@ -15,6 +15,8 @@ endif
 
 if !HAVE_TIME
 $(error Did not find "time" in the PATH.)
+else
+TIMER = $(TIME) -v
 endif
 
 
@@ -33,9 +35,9 @@ $(LOCAL_DIR)/config.h: $(LOCAL_DIR)
 
 $(BENCHOUT): $(LOCAL_DIR)/config.h
 	cd $(LOCAL_DIR) && make clean
-	cd $(LOCAL_DIR) && $(TIME) make
+	cd $(LOCAL_DIR) && $(TIMER) make
 	cd $(LOCAL_DIR) && make clean
-	cd $(LOCAL_DIR) && $(TIME) ../$(EXE) make
+	cd $(LOCAL_DIR) && $(TIMER) ../$(EXE) make
 
 compile_single_file: f1.c
 	$(EXE) -o $@.out $(CC) -c $^

--- a/configure.ac
+++ b/configure.ac
@@ -26,12 +26,12 @@ dnl Where are the sources
 AC_CONFIG_SRCDIR([src/main.c])
 
 dnl Checks for programs
-AC_CHECK_PROGS(DOWNLOAD, curl, [curl -O])
+AC_CHECK_PROG(DOWNLOAD, curl, [curl -O])
 if test "x$DOWNLOAD" = x; then
-    AC_CHECK_PROGS(DOWNLOAD, wget, wget)
+    AC_CHECK_PROG(DOWNLOAD, wget, wget)
 fi
 AM_CONDITIONAL([HAVE_DOWNLOAD], [test -n "$DOWNLOAD"])
-AC_CHECK_PROGS(TIME, time, time -v)
+AC_PATH_PROG(TIME, time)
 AM_CONDITIONAL([HAVE_TIME], [test -n "$TIME"])
 
 dnl Checks for libraries


### PR DESCRIPTION
- fixes typo (PROG instead of PROGS)
- uses full path for time

closes #198
closes #199
