### PR TITLE
configure.ac: Add option to configure script for benchmarks.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,5 +5,8 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src examples benchmark
+SUBDIRS = src examples
 
+if ENABLE_BENCHMARKS
+SUBDIRS += benchmark
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ AC_CONFIG_HEADERS([src/config.h])
 dnl Where are the sources
 AC_CONFIG_SRCDIR([src/main.c])
 
+AC_ARG_ENABLE([benchmarks],
+	      [AS_HELP_STRING([--enable-benchmarks], [exclude benchmarks (default: disabled)])],
+	      [enable_benchmarks=$enableval],
+	      [enable_benchmarks=no])
+
+AM_CONDITIONAL([ENABLE_BENCHMARKS], [test "x$enable_benchmarks" = "xyes"])
+
 dnl Checks for programs
 AC_CHECK_PROG(DOWNLOAD, curl, [curl -O])
 if test "x$DOWNLOAD" = x; then


### PR DESCRIPTION
As discussed in #205, this commit makes it so
that building the benchmark directory is optional
and disabled by default. I'd argue opt-in is superior in our case since benchmarks are only relevant to the developers of this project.

This allows us to add a as many dependencies to benchmark as we possibly want or need, without minding the extra dependencies that we add to the project.

We still have to face the fact that different benchmark targets have different dependencies and perhaps we'd want to provide options for each separate benchmark but I find this too complicated.