### PR TITLE
Fixed an issue where headers and schema needed to build build-recorder were not included in the generated tarball after running 'make dist'.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,8 +12,11 @@ build_recorder_SOURCES = \
 	tracer.c \
 	$(EMPTY)
 
+dist_noinst_HEADERS = *.h
+
 SCHEMA = ../doc/build-recorder-schema.ttl
 
+dist_data_DATA = $(SCHEMA)
 
 if HAVE_XXD
 schema.c: $(SCHEMA)


### PR DESCRIPTION
Closes #212, Closes #209 